### PR TITLE
fix: focus editor after shortcut selection

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -143,6 +143,7 @@ export function OverflowingToolbar({ children }: OverflowingToolbarProps) {
 			if (typeof index === 'number') {
 				preventDefault(event)
 				rButtons.current[index]?.click()
+				editor.focus()
 			}
 		}
 


### PR DESCRIPTION
When you select a shortcut like `r` for rectangle, the behaviour is that it basically click the rectangle shape tool/component. That takes focus away from the editor. Therefore I can't immediately draw unless I refocus by hand. Here I am just automatically refocusing the editor for a better UX.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Press a shortcut
2. You should be able to immediately draw the shape without weird double clicking to refocus editor.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve shortcut UX by refocusing the editor